### PR TITLE
Update Office-Meeting-Indicator-V2.md

### DIFF
--- a/content/blog/Office-Meeting-Indicator-V2.md
+++ b/content/blog/Office-Meeting-Indicator-V2.md
@@ -1,6 +1,6 @@
 ---
 title: "Office Meeting Indicator Version 2"
-date: 2024-11-29T01:16:44-06:00
+date: 2024-12-01T07:24:08-05:00
 draft: false
 tags: ["Home Assistant","Github"]
 ---


### PR DESCRIPTION
This pull request includes a small change to the `content/blog/Office-Meeting-Indicator-V2.md` file. The change updates the date of the blog post to reflect a new publication date.

* [`content/blog/Office-Meeting-Indicator-V2.md`](diffhunk://#diff-1e7bb0c6883042ef6ce8145ed52156d49661df3cf31093694fdb1b53693480bfL3-R3): Updated the date of the blog post from "2024-11-29" to "2024-12-01".