### PR TITLE
Update Office Meeting Indicator post with new images and layout adjus…

### DIFF
--- a/content/blog/Office-Meeting-Indicator.md
+++ b/content/blog/Office-Meeting-Indicator.md
@@ -5,9 +5,12 @@ date: 2025-07-06T08:00:00-05:00
 draft: false
 tags: ["Home Assistant", "Automation", "ESP32-S3", "ESPHome", "Work From Home"]
 ---
+<div style="display: flex; justify-content: center; gap: 2rem;">
+    <img src="https://gogorichiesitefiles.blob.core.windows.net/publicfiles/osf/ESP_Home_logo3.svg" alt="ESPHome" style="width: 200px;"/>
+    <img src="https://gogorichiesitefiles.blob.core.windows.net/publicfiles/osf/home-assistant-wordmark-monochrome-on-light.png" alt="Home Assistant" style="width: 200px;"/>
+</div>
 
-<img src="https://gogorichiesitefiles.blob.core.windows.net/publicfiles/esphome+halogo.png" alt="ESPHome + Home Assistant" style="width:50%; display:block; margin:auto;" />
-
+<br/>
 
 Like many folks post-2020, I’ve been working from home a lot more, and with that came a new set of challenges — one of them being how to let my family know when I’m in a meeting without yelling across the house or hanging a note on the door. I decided to solve that problem the way any tech nerd would — with a bit of home automation magic.
 


### PR DESCRIPTION
This pull request updates the visuals in the blog post `Office-Meeting-Indicator.md` to enhance the presentation of logos and improve layout consistency.

### Visual updates:

* Replaced the single combined logo image with two separate logo images for `ESPHome` and `Home Assistant`, displayed side-by-side with consistent sizing and spacing.
* Added a `<div>` element with styling for centered alignment and gap spacing to improve the layout of the logos.
* Removed the older combined logo image and adjusted the layout to include a `<br/>` for better spacing.